### PR TITLE
7.16 改进S图的构建过程，使用nx自带函数

### DIFF
--- a/graph_s_graph.py
+++ b/graph_s_graph.py
@@ -12,7 +12,17 @@ import os.path
 import class_circuit as cc
 ###############################################################################
 class s_graph(nx.DiGraph):
-    def __init__(self,name,edge_set,vertex_set,include_pipo=True,verbose=False): 
+    '''
+        S-图，只有D触发器以及它们之间的依赖关系的图
+    '''
+    def __init__(self,include_pipo):
+        nx.DiGraph.__init__(self)
+        self.include_pipo=include_pipo
+        self.name=None
+        self.pi_nodes=[]
+        self.po_nodes=[]
+        self.fd_nodes=[]
+    def old__init__(self,name,edge_set,vertex_set,include_pipo=True,verbose=False): 
         nx.DiGraph.__init__(self)
         self.include_pipo=include_pipo
         ##设置保留下来的节点类型,如果m_type在该list中,就不进行ignore
@@ -151,21 +161,22 @@ class s_graph(nx.DiGraph):
         plt.savefig(pic_full_name) 
         
     ###########################################################################
-    def info(self):
-        print 'Info: s_vertex:---------------------------------------------'
-        for eachVertex in self.nodes_iter():
-            if isinstance(eachVertex,cc.circut_module):
-                print eachVertex.m_type+':'+eachVertex.name
-            else:
-                print eachVertex.port_type+':'+eachVertex.port_name
-        print 'Info: s_edge  :--------------------------------------------'
-        for eachEdge in self.edges_iter():
-            print "%s --->>%s "%(eachEdge[0].name,eachEdge[1].name)
-        print "S_graph info:nx.info(self)---------------------------------"             
+    def info(self,verbose=False):
+        if verbose:
+            print 'Info: s_vertex:---------------------------------------------'
+            for eachVertex in self.nodes_iter():
+                if isinstance(eachVertex,cc.circut_module):
+                    print eachVertex.m_type+':'+eachVertex.name
+                else:
+                    print eachVertex.port_type+':'+eachVertex.port_name
+            print 'Info: s_edge  :--------------------------------------------'
+            for eachEdge in self.edges_iter():
+                print "%s --->>%s "%(eachEdge[0].name,eachEdge[1].name)
+            print "S_graph info:nx.info(self)---------------------------------"             
         print nx.info(self)
         print "Info: nodes with selfloops ARE:----------------------------"
         for eachNode in self.nodes_with_selfloops():
-            print eachNode
+            print eachNode.name
     ###########################################################################        
     def compu_fds_depth(self,verbose):
         for eachFD in self.fd_nodes:

--- a/graph_top.py
+++ b/graph_top.py
@@ -10,7 +10,7 @@ paint_order= include_pipo
 display_pipo=include_pipo
 ##-----------------------------------------------
 import matplotlib.pylab as plt
-
+import networkx       as nx
 import netlist_util   as nu
 from   graph_util    import circuit_graph 
 from   graph_s_graph import s_graph
@@ -28,16 +28,19 @@ def get_graph(fname):
     
     cloud_reg1=g1.get_cloud_reg_graph()
     cloud_reg1.info()
-
-    s1=s_graph(fname,g1.edge_set,g1.vertex_set,g1.include_pipo,verbose=False)
-    s1.info()
+    if not cloud_reg1.check_rules():
+        raise AssertionError
+#    s2=s_graph(fname,g1.edge_set,g1.vertex_set,g1.include_pipo,verbose=False)
+#    s2.info()
+    s1=g1.get_s_graph()
+    print nx.info(s1)
 #    ##显示原始的电路结构图
-    plt.figure("Original_Circut")
-    g1.paint()
-    plt.figure("Cloud_reg")
-    cloud_reg1.paint()
-    plt.figure("S_Graph")    
-    s1.paint(display_pipo,paint_order)
+#    plt.figure("Original_Circut")
+#    g1.paint()
+#    plt.figure("Cloud_reg")
+#    cloud_reg1.paint()
+#    plt.figure("S_Graph")    
+#    s1.paint(display_pipo,paint_order)
     
     return True
     


### PR DESCRIPTION
1.原有的构建S图的过程完全依赖于边集合点集进行操作，每一个点搜索其前驱结点与后继节点时，都需要完全的重新搜索整个边集。所以最坏情况下的算法复杂度为N*M^2.其中N是非触发器节点的数目，M是边的数目。
新算法采用nx.DiVGraph的成员函数
G.predecessors和G.successors来代替原先的搜索，擦除一个点不需要搜索整个边集，所以会更加快速。
2.完善一些函数的注释。和打印信息。
